### PR TITLE
Fix comments being disabled causing an error.

### DIFF
--- a/codegen.js
+++ b/codegen.js
@@ -161,7 +161,7 @@ const nodeHandlers = {
     return node.raw;
   },
   Chunk(node) {
-    return [...node.comments.map(gen), ...node.body.map(gen)].join("\n");
+    return [...(node.comments || []).map(gen), ...node.body.map(gen)].join("\n");
   }
 };
 


### PR DESCRIPTION
If comments are disabled in `luaparse` through the secondary `options` parameter, there is no `comments` array defined, which causes the error below. This error occurs regardless of comments being present or absent in the code.

> TypeError: Cannot read property 'map' of undefined

Example code:

```javascript
const luaparse = require('luaparse');
const codegen = require('luacodegen');

const code = 'print(true)';

const ast = luaparse.parse(code, {'comments': false});
const formatted = codegen(ast);

console.log(formatted);
```